### PR TITLE
update 11.10

### DIFF
--- a/src/components/Quiz.vue
+++ b/src/components/Quiz.vue
@@ -53,7 +53,7 @@
          <input class="u-full-width" type="email" v-bind:placeholder="$t('quiz_form.l_name')" id="lastnameInput" v-model="cons_last_name">
          <input class="u-full-width" type="numeric" v-bind:placeholder="$t('quiz_form.number')" id="numberInput" v-model="$v.cons_number.$model">
          <input class="u-full-width" type="email" v-bind:placeholder="$t('quiz_form.email')" id="emailInput" v-model="$v.cons_email.$model">
-         <span v-show="$v.cons_first_name.$error || $v.cons_email.$error || formInfo" style="color: #ea0029">*Name and Email fields are required</span>
+         <span v-show="$v.cons_first_name.$error || $v.cons_email.$error || formInfo" style="color: #ea0029">{{ $t('quiz_form.warning') }}</span>
          <span v-show="error" style="color: #ea0029">{{error}}</span>
          <label class="agree">
                    <input type="checkbox" checked>
@@ -169,7 +169,10 @@
       cons_first_name: {
         required
       },
-      validationGroup: ['cons_email', 'cons_first_name', 'cons_number']
+      cons_last_name: {
+        required
+      },
+      validationGroup: ['cons_email', 'cons_first_name', 'cons_last_name','cons_number']
     },
     methods: {
       handleTouchStart: function (evt) {
@@ -502,8 +505,9 @@
       },
       formInfo() {
        let fname = this.cons_first_name.length
+       let lname = this.cons_last_name.length
        let eml = this.cons_email.length
-       return (fname > 0 && eml > 0) ? false : true 
+       return (fname > 0 && lname > 0 && eml > 0) ? false : true 
       }
     }
   }

--- a/src/lib/copies.js
+++ b/src/lib/copies.js
@@ -34,11 +34,12 @@ const copies = {
           continue: 'continue',
           skip: 'Skip this step',
           f_name: 'First Name*',
-          l_name: 'Last Name',
+          l_name: 'Last Name*',
           email: 'Email*',
-          number: 'Phone Number (Optional)',
+          number: 'Phone Number',
           back: 'Back',
-          privacy_policy: 'http://www.doctorswithoutborders.ca/privacy-notice'
+          privacy_policy: 'http://www.doctorswithoutborders.ca/privacy-notice',
+          warning: '*Name and Email fields are required'
         },
     profile:
         {
@@ -87,11 +88,12 @@ const copies = {
           continue: 'continuer',
           skip: 'Passer cette étape',
           f_name: 'Prénom*',
-          l_name: 'Nom de famille',
+          l_name: 'Nom de famille*',
           email: 'Email*',
-          number: 'Numéro de téléphone (Optionnel)',
+          number: 'Numéro de téléphone',
           back: 'Précédent',
-          privacy_policy: 'http://www.medecinssansfrontieres.ca/avis-de-confidentialit%C3%A9'
+          privacy_policy: 'http://www.medecinssansfrontieres.ca/avis-de-confidentialit%C3%A9',
+          warning: '*Nom et Courriel sont des champs obligatoires'
         },
     profile:
         {


### PR DESCRIPTION
- FR: we need to show the French version for the “name and email are required fields”
Please replace that text with: Nom et Courriel sont des champs obligatoires.

- Please remove the (optional) on phone number. EN & FR
The field would remain optional, its just the text that we need to remove

- Add an asterisk under “Last Name” and make this field a required one too.